### PR TITLE
Normalize and restructure routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restaurant Pro</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mui/icons-material": "^5.15.0",
+    "@mui/material": "^5.15.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,2 @@
+<!-- TODO: add real favicon -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#8b1538"/></svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,5 @@
+import RoutesIndex from './routes';
+
+export default function App() {
+  return <RoutesIndex />;
+}

--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer style={{ padding: '12px 24px', borderTop: '1px solid #eee', fontSize: 12, textAlign: 'center' }}>
+      © {new Date().getFullYear()} RestaurantPro
+    </footer>
+  );
+}

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router-dom';
+import Sidebar from './Sidebar';
+import Navbar from './Navbar';
+import Footer from './Footer';
+
+export default function Layout() {
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <Navbar />
+        <main style={{ flex: 1, padding: 24 }}>
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout/Navbar.jsx
+++ b/src/components/Layout/Navbar.jsx
@@ -1,0 +1,7 @@
+export default function Navbar() {
+  return (
+    <header style={{ padding: '16px 24px', borderBottom: '1px solid #eee' }}>
+      <span style={{ fontWeight: 500 }}>Painel do restaurante</span>
+    </header>
+  );
+}

--- a/src/components/Layout/Sidebar.css
+++ b/src/components/Layout/Sidebar.css
@@ -1,0 +1,21 @@
+.sidebar {
+  width: 220px;
+  background: #faf8f5;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+}
+.sidebar .logo {
+  font-weight: bold;
+  margin-bottom: 24px;
+}
+.sidebar a {
+  color: #2d1b1e;
+  text-decoration: none;
+  display: block;
+  padding: 8px 0;
+}
+.sidebar a.active {
+  color: #8b1538;
+  font-weight: bold;
+}

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -1,0 +1,27 @@
+import { Link, useLocation } from 'react-router-dom';
+import './Sidebar.css';
+
+export default function Sidebar() {
+  const { pathname } = useLocation();
+  const links = [
+    { to: '/', label: 'Dashboard' },
+    { to: '/kitchen', label: 'Cozinha' },
+    { to: '/menu', label: 'Cardápio' },
+    { to: '/orders', label: 'Pedidos' },
+    { to: '/stock', label: 'Estoque' },
+    { to: '/categories', label: 'Categorias' },
+    { to: '/ingredients', label: 'Ingredientes' }
+  ];
+  return (
+    <aside className="sidebar">
+      <h2 className="logo">RestaurantPro</h2>
+      <nav>
+        {links.map(l => (
+          <Link key={l.to} to={l.to} className={pathname === l.to ? 'active' : ''}>
+            {l.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/UI/Badge.jsx
+++ b/src/components/UI/Badge.jsx
@@ -1,0 +1,13 @@
+export default function Badge({ children }) {
+  return (
+    <span style={{
+      background: '#d4af37',
+      color: '#2d1b1e',
+      padding: '2px 6px',
+      borderRadius: 4,
+      fontSize: 12
+    }}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/UI/Button.jsx
+++ b/src/components/UI/Button.jsx
@@ -1,0 +1,4 @@
+import ButtonMUI from '@mui/material/Button';
+export default function Button(props) {
+  return <ButtonMUI variant="contained" color="primary" {...props} />;
+}

--- a/src/components/UI/Card.jsx
+++ b/src/components/UI/Card.jsx
@@ -1,0 +1,9 @@
+import CardMUI from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+export default function Card({ children, ...rest }) {
+  return (
+    <CardMUI variant="outlined" {...rest}>
+      <CardContent>{children}</CardContent>
+    </CardMUI>
+  );
+}

--- a/src/components/UI/DataTable.jsx
+++ b/src/components/UI/DataTable.jsx
@@ -1,0 +1,21 @@
+import { Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
+export default function DataTable({ rows }) {
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>ID</TableCell>
+          <TableCell>Nome</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(r => (
+          <TableRow key={r.id}>
+            <TableCell>{r.id}</TableCell>
+            <TableCell>{r.name}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/UI/SearchInput.jsx
+++ b/src/components/UI/SearchInput.jsx
@@ -1,0 +1,4 @@
+import TextField from '@mui/material/TextField';
+export default function SearchInput(props) {
+  return <TextField size="small" placeholder="Buscar..." {...props} />;
+}

--- a/src/components/UI/Tabs.jsx
+++ b/src/components/UI/Tabs.jsx
@@ -1,0 +1,10 @@
+import { Tabs as MUITabs, Tab } from '@mui/material';
+export default function Tabs({ tabs, current, onChange }) {
+  return (
+    <MUITabs value={current} onChange={(e, v) => onChange(v)}>
+      {tabs.map(t => (
+        <Tab key={t.value} label={t.label} value={t.value} />
+      ))}
+    </MUITabs>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import App from './App';
+import theme from './theme/theme';
+import './styles/globals.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/src/mocks/sample-data.js
+++ b/src/mocks/sample-data.js
@@ -1,0 +1,9 @@
+export const sampleOrders = [
+  { id: 1, customer: 'João', total: 89.9, status: 'pendente' },
+  { id: 2, customer: 'Maria', total: 45.0, status: 'pronto' }
+];
+
+export const menuItems = [
+  { id: 1, name: 'Pizza Margherita', price: 32.0 },
+  { id: 2, name: 'Lasanha', price: 28.5 }
+];

--- a/src/pages/Categories/Categories.jsx
+++ b/src/pages/Categories/Categories.jsx
@@ -1,0 +1,8 @@
+export default function Categories() {
+  return (
+    <div>
+      <h1>Categorias de Produtos</h1>
+      <p>Gestão de categorias conforme Figma.</p>
+    </div>
+  );
+}

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1,0 +1,10 @@
+import Card from '../../components/UI/Card';
+
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <Card>Conteúdo de indicadores do Figma</Card>
+    </div>
+  );
+}

--- a/src/pages/Ingredients/Ingredients.jsx
+++ b/src/pages/Ingredients/Ingredients.jsx
@@ -1,0 +1,8 @@
+export default function Ingredients() {
+  return (
+    <div>
+      <h1>Gestão de Ingredientes</h1>
+      <p>Painel de insumos do restaurante.</p>
+    </div>
+  );
+}

--- a/src/pages/Kitchen/Kitchen.jsx
+++ b/src/pages/Kitchen/Kitchen.jsx
@@ -1,0 +1,8 @@
+export default function Kitchen() {
+  return (
+    <div>
+      <h1>Painel da Cozinha</h1>
+      <p>UI baseada no frame KitchenPanel do Figma.</p>
+    </div>
+  );
+}

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,0 +1,22 @@
+import Button from '../../components/UI/Button';
+import { TextField, Paper } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const navigate = useNavigate();
+  const handleSubmit = e => {
+    e.preventDefault();
+    navigate('/');
+  };
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: '#f5f5f5' }}>
+      <Paper style={{ padding: 32, maxWidth: 360 }}>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <TextField label="Email" required />
+          <TextField label="Senha" type="password" required />
+          <Button type="submit">Entrar</Button>
+        </form>
+      </Paper>
+    </div>
+  );
+}

--- a/src/pages/Menu/Menu.jsx
+++ b/src/pages/Menu/Menu.jsx
@@ -1,0 +1,8 @@
+export default function Menu() {
+  return (
+    <div>
+      <h1>Gestão de Cardápio</h1>
+      <p>Componentes e tabelas conforme design.</p>
+    </div>
+  );
+}

--- a/src/pages/Orders/Orders.jsx
+++ b/src/pages/Orders/Orders.jsx
@@ -1,0 +1,8 @@
+export default function Orders() {
+  return (
+    <div>
+      <h1>Pedidos</h1>
+      <p>Lista de pedidos com filtros.</p>
+    </div>
+  );
+}

--- a/src/pages/Stock/Stock.jsx
+++ b/src/pages/Stock/Stock.jsx
@@ -1,0 +1,8 @@
+export default function Stock() {
+  return (
+    <div>
+      <h1>Controle de Estoque</h1>
+      <p>Dados de itens do estoque.</p>
+    </div>
+  );
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,0 +1,34 @@
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import Layout from '../components/Layout/Layout';
+import Login from '../pages/Login/Login';
+import Dashboard from '../pages/Dashboard/Dashboard';
+import Kitchen from '../pages/Kitchen/Kitchen';
+import Menu from '../pages/Menu/Menu';
+import Orders from '../pages/Orders/Orders';
+import Stock from '../pages/Stock/Stock';
+import Categories from '../pages/Categories/Categories';
+import Ingredients from '../pages/Ingredients/Ingredients';
+
+export default function RoutesIndex() {
+  const { pathname } = useLocation();
+  const lowerPath = pathname.toLowerCase();
+  if (pathname !== lowerPath) {
+    return <Navigate to={lowerPath} replace />;
+  }
+
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route element={<Layout />}> 
+        <Route index element={<Dashboard />} />
+        <Route path="kitchen" element={<Kitchen />} />
+        <Route path="menu" element={<Menu />} />
+        <Route path="orders" element={<Orders />} />
+        <Route path="stock" element={<Stock />} />
+        <Route path="categories" element={<Categories />} />
+        <Route path="ingredients" element={<Ingredients />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+:root {
+  --background: #fefefe;
+  --foreground: #2d1b1e;
+  --primary: #8b1538;
+  --secondary: #d4af37;
+}
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: 'Inter', sans-serif;
+}

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,0 +1,20 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: { main: '#8b1538', contrastText: '#fefefe' },
+    secondary: { main: '#d4af37', contrastText: '#2d1b1e' },
+    background: { default: '#fefefe', paper: '#ffffff' },
+    text: { primary: '#2d1b1e', secondary: '#6b5b5e' }
+  },
+  typography: {
+    fontFamily: 'Inter, sans-serif',
+    h1: { fontSize: '2rem', fontWeight: 700 },
+    h2: { fontSize: '1.5rem', fontWeight: 700 },
+    body1: { fontSize: '1rem' }
+  },
+  shape: { borderRadius: 12 },
+  shadows: Array(25).fill('0px 2px 8px rgba(0,0,0,0.05)')
+});
+
+export default theme;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 }
+});


### PR DESCRIPTION
## Summary
- normalize pathnames to lowercase before routing
- use index and relative paths under layout with catch-all redirect

## Testing
- `npm test` *(fails: Missing script "test"))*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e95d0f97883269101debfc0f8b48a